### PR TITLE
Pull Request for OverlayView

### DIFF
--- a/Classes/ExamplesViewController.m
+++ b/Classes/ExamplesViewController.m
@@ -10,8 +10,9 @@
 #import "PDFExampleViewController.h"
 #import "ImageExampleViewController.h"
 #import "ProceduralExampleViewController.h"
+#import "OverlayExampleViewController.h"
 
-enum {PDF, IMAGE, PROCEDURAL, NUM_EXAMPLES};
+enum {PDF, IMAGE, PROCEDURAL, OVERLAY, NUM_EXAMPLES};
 
 @implementation ExamplesViewController
 
@@ -51,6 +52,7 @@ enum {PDF, IMAGE, PROCEDURAL, NUM_EXAMPLES};
 		case PDF: cell.textLabel.text = @"PDF example"; break;
 		case IMAGE: cell.textLabel.text = @"Image example"; break;
 		case PROCEDURAL: cell.textLabel.text = @"Procedural example"; break;
+		case OVERLAY: cell.textLabel.text = @"Overlay example"; break;
 		default: cell.textLabel.text = @"";
 	}    
     return cell;
@@ -69,6 +71,9 @@ enum {PDF, IMAGE, PROCEDURAL, NUM_EXAMPLES};
 			break;
 		case PROCEDURAL:
 			viewController = [[[ProceduralExampleViewController alloc] init] autorelease]; 
+			break;
+		case OVERLAY:
+			viewController = [[[OverlayExampleViewController alloc] initWithNibName:@"OverlayExampleViewController" bundle:nil] autorelease]; 
 			break;
 		default: 
 			viewController = [[[UIViewController alloc] init] autorelease];

--- a/Classes/OverlayExampleViewController.h
+++ b/Classes/OverlayExampleViewController.h
@@ -1,0 +1,31 @@
+//
+//  OverlayExampleViewController.h
+//  Leaves
+//
+//  Created by Robert Simpson on 8/26/10.
+//  Copyright 2010 Tom Brow. All rights reserved.
+//
+
+#import "LeavesViewController.h"
+
+@class OverlayView;
+
+@interface OverlayExampleViewController : LeavesViewController {
+
+   OverlayView * overlayView;
+   
+   UISwitch * onOffSwitch;
+   
+   UILabel * label;
+
+}
+
+@property (nonatomic, retain) IBOutlet OverlayView * overlayView;
+
+@property (nonatomic, retain) IBOutlet UISwitch * onOffSwitch;
+
+@property (nonatomic, retain) IBOutlet UILabel * label;
+
+- (IBAction)switchValueChanged:(id)sender;
+
+@end

--- a/Classes/OverlayExampleViewController.m
+++ b/Classes/OverlayExampleViewController.m
@@ -1,0 +1,72 @@
+//
+//  OverlayExampleViewController.m
+//  Leaves
+//
+//  Created by Robert Simpson on 8/26/10.
+//  Copyright 2010 Tom Brow. All rights reserved.
+//
+
+#import "OverlayExampleViewController.h"
+#import "OverlayView.h"
+
+@implementation OverlayExampleViewController
+
+@synthesize overlayView, onOffSwitch, label;
+
+- (void) displayPageNumber:(NSUInteger)pageNumber
+{
+	self.navigationItem.title = [NSString stringWithFormat:
+                                @"Page %u of %u", 
+                                pageNumber, 
+                                [self numberOfPagesInLeavesView:leavesView]];
+}
+
+- (void)viewDidLoad
+{
+   [self displayPageNumber:1];
+   [OverlayView addOverlayView:overlayView onView:self.view];
+   [super viewDidLoad];
+}
+
+- (IBAction)switchValueChanged:(id)sender
+{
+   if ([onOffSwitch isOn]) {
+      [self displayPageNumber:leavesView.currentPageIndex + 1];
+   }
+   else {
+      self.navigationItem.title = nil;
+   }
+}
+
+#pragma mark  LeavesViewDelegate methods
+
+- (void) leavesView:(LeavesView *)leavesView 
+   willTurnToPageAtIndex:(NSUInteger)pageIndex
+{
+   NSString * str = [[NSString alloc] initWithFormat:@"willTurnToPageAtIndex:%d", pageIndex];
+   [label setText:str];
+   [str release];
+   if ([onOffSwitch isOn]) {
+      [self displayPageNumber:pageIndex + 1];
+   }
+}
+
+#pragma mark LeavesViewDataSource methods
+
+- (NSUInteger) numberOfPagesInLeavesView:(LeavesView*)leavesView
+{
+	return 10;
+}
+
+- (void) renderPageAtIndex:(NSUInteger)index
+   inContext:(CGContextRef)ctx
+{
+	CGRect bounds = CGContextGetClipBoundingBox(ctx);
+	CGContextSetFillColorWithColor(ctx, [[UIColor colorWithHue:index/10.0 
+                                                   saturation:0.8
+                                                   brightness:0.8 
+                                                        alpha:1.0] CGColor]);
+	CGContextFillRect(ctx, CGRectInset(bounds, 100, 100));
+}
+
+@end

--- a/Leaves.xcodeproj/project.pbxproj
+++ b/Leaves.xcodeproj/project.pbxproj
@@ -27,6 +27,9 @@
 		D33D4F01117D8EAE00BA7203 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = D33D4F00117D8EAE00BA7203 /* main.m */; };
 		D33D4F41117E244C00BA7203 /* ExamplesViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = D33D4F40117E244C00BA7203 /* ExamplesViewController.m */; };
 		D33D5176117E780300BA7203 /* ProceduralExampleViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = D33D5175117E780300BA7203 /* ProceduralExampleViewController.m */; };
+		DD285C3F12272ED900570237 /* OverlayExampleViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = DD285C3E12272ED900570237 /* OverlayExampleViewController.xib */; };
+		DD285C5412272F4200570237 /* OverlayExampleViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = DD285C5212272F4200570237 /* OverlayExampleViewController.m */; };
+		DDE1A7E51227306D0056C938 /* OverlayView.m in Sources */ = {isa = PBXBuildFile; fileRef = DDE1A7E41227306D0056C938 /* OverlayView.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -62,6 +65,11 @@
 		D33D4F40117E244C00BA7203 /* ExamplesViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ExamplesViewController.m; sourceTree = "<group>"; };
 		D33D5174117E780300BA7203 /* ProceduralExampleViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ProceduralExampleViewController.h; sourceTree = "<group>"; };
 		D33D5175117E780300BA7203 /* ProceduralExampleViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ProceduralExampleViewController.m; sourceTree = "<group>"; };
+		DD285C3E12272ED900570237 /* OverlayExampleViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = OverlayExampleViewController.xib; sourceTree = "<group>"; };
+		DD285C5112272F4200570237 /* OverlayExampleViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OverlayExampleViewController.h; sourceTree = "<group>"; };
+		DD285C5212272F4200570237 /* OverlayExampleViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OverlayExampleViewController.m; sourceTree = "<group>"; };
+		DDE1A7E31227306D0056C938 /* OverlayView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OverlayView.h; sourceTree = "<group>"; };
+		DDE1A7E41227306D0056C938 /* OverlayView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OverlayView.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -92,6 +100,8 @@
 				D33D4F40117E244C00BA7203 /* ExamplesViewController.m */,
 				D33D5174117E780300BA7203 /* ProceduralExampleViewController.h */,
 				D33D5175117E780300BA7203 /* ProceduralExampleViewController.m */,
+				DD285C5112272F4200570237 /* OverlayExampleViewController.h */,
+				DD285C5212272F4200570237 /* OverlayExampleViewController.m */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -146,6 +156,8 @@
 				D33D4E58117D818100BA7203 /* LeavesView.m */,
 				D33D4E59117D818100BA7203 /* LeavesViewController.h */,
 				D33D4E5A117D818100BA7203 /* LeavesViewController.m */,
+				DDE1A7E31227306D0056C938 /* OverlayView.h */,
+				DDE1A7E41227306D0056C938 /* OverlayView.m */,
 			);
 			path = Leaves;
 			sourceTree = "<group>";
@@ -170,6 +182,7 @@
 				D33D4EC6117D8D4500BA7203 /* kitten2.jpg */,
 				D33D4EC7117D8D4500BA7203 /* kitten3.jpg */,
 				D33D4ECA117D8D4500BA7203 /* paper.pdf */,
+				DD285C3E12272ED900570237 /* OverlayExampleViewController.xib */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -225,6 +238,7 @@
 				D33D4ECF117D8D4500BA7203 /* kitten3.jpg in Resources */,
 				D33D4ED1117D8D4500BA7203 /* MainWindow.xib in Resources */,
 				D33D4ED2117D8D4500BA7203 /* paper.pdf in Resources */,
+				DD285C3F12272ED900570237 /* OverlayExampleViewController.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -245,6 +259,8 @@
 				D33D4F41117E244C00BA7203 /* ExamplesViewController.m in Sources */,
 				D33D5176117E780300BA7203 /* ProceduralExampleViewController.m in Sources */,
 				D337E308119B61A5003E5728 /* LeavesCache.m in Sources */,
+				DD285C5412272F4200570237 /* OverlayExampleViewController.m in Sources */,
+				DDE1A7E51227306D0056C938 /* OverlayView.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Leaves/LeavesView.h
+++ b/Leaves/LeavesView.h
@@ -60,6 +60,7 @@
 
 // refreshes the contents of all pages via the data source methods, much like -[UITableView reloadData]
 - (void) reloadData;
+- (void) reloadDataWithPageIndex:(NSUInteger)newPageIndex;
 
 @end
 

--- a/Leaves/LeavesView.m
+++ b/Leaves/LeavesView.m
@@ -122,7 +122,7 @@ CGFloat distance(CGPoint a, CGPoint b);
 - (void) reloadData {
 	[pageCache flush];
 	numberOfPages = [pageCache.dataSource numberOfPagesInLeavesView:self];
-	self.currentPageIndex = 0;
+//	self.currentPageIndex = 0; // moved to layoutSubviews
 }
 
 - (void) getImages {
@@ -357,7 +357,8 @@ CGFloat distance(CGPoint a, CGPoint b);
 		[self setLayerFrames];
 		[CATransaction commit];
 		pageCache.pageSize = self.bounds.size;
-		[self getImages];
+//		[self getImages];
+		self.currentPageIndex = 0;
 		[self updateTargetRects];
 	}
 }

--- a/Leaves/LeavesView.m
+++ b/Leaves/LeavesView.m
@@ -119,10 +119,19 @@ CGFloat distance(CGPoint a, CGPoint b);
     [super dealloc];
 }
 
-- (void) reloadData {
+- (void) loadData {
+	numberOfPages = [pageCache.dataSource numberOfPagesInLeavesView:self];
+   // getImages defered until layoutSubvies
+}
+
+- (void) reloadDataWithPageIndex:(NSUInteger)newPageIndex {
 	[pageCache flush];
 	numberOfPages = [pageCache.dataSource numberOfPagesInLeavesView:self];
-//	self.currentPageIndex = 0; // moved to layoutSubviews
+	self.currentPageIndex = newPageIndex;
+}
+
+- (void) reloadData {
+   [self reloadDataWithPageIndex:currentPageIndex];
 }
 
 - (void) getImages {

--- a/Leaves/LeavesViewController.m
+++ b/Leaves/LeavesViewController.m
@@ -8,6 +8,10 @@
 
 #import "LeavesViewController.h"
 
+@interface LeavesView ()
+- (void) loadData;
+@end
+
 @implementation LeavesViewController
 
 - (void) initialize {
@@ -59,7 +63,7 @@
 	[super viewDidLoad];
 	leavesView.dataSource = self;
 	leavesView.delegate = self;
-	[leavesView reloadData];
+	[leavesView loadData];
 }
 
 @end

--- a/Leaves/OverlayView.h
+++ b/Leaves/OverlayView.h
@@ -1,0 +1,56 @@
+//
+//  OverlayView.h
+//  oKnow
+//
+//  Created by Robert Simpson on 8/1/10.
+//  Copyright 2010 Accilent Corp. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@class LeavesView;
+
+/**
+ * <p>Usage:
+ * </p>
+ *
+ * <p>in ...ViewController.h:
+ * </p>
+ * <xmp>
+ *
+ *    IBOutlet OverlayView * overlayView;
+ *
+ * </xmp>
+ * <p>If using a NIB, connect the view outlet of the File's Owner to the UIView and connect
+ *    the overlayView outlet to a view with Class OverlayView in the Identity Inspector.
+ * </p>
+ *
+ * <p>in ...ViewController.m viewDidLoad:
+ * </p>
+ * <xmp>
+ *
+ *    [OverlayView addOverlayView:overlayView onView:self.view];
+ *
+ * </xmp>
+ * </p>
+**/
+
+@interface OverlayView : UIView {
+
+/**
+ * <p>The LeavesViewController gives us access to the LeavesView,
+ *    since the LeavesView itself is not available to Interface Builder.
+ * </p>
+**/
+
+   LeavesView * leavesView;
+
+   BOOL touchesBeganInLeavesView;
+
+}
+
+@property (nonatomic, retain) LeavesView * leavesView;
+
++ (void)addOverlayView:(OverlayView *)overlayView onView:(UIView *)view;
+
+@end

--- a/Leaves/OverlayView.m
+++ b/Leaves/OverlayView.m
@@ -1,0 +1,95 @@
+//
+//  OverlayView.m
+//  oKnow
+//
+//  Created by Robert Simpson on 8/1/10.
+//  Copyright 2010 Accilent Corp. All rights reserved.
+//
+
+#import "OverlayView.h"
+#import "LeavesViewController.h"
+
+@implementation OverlayView
+
+#pragma mark -
+#pragma mark Accessor methods
+
+@synthesize leavesView;
+
+
+#pragma mark -
+#pragma mark Class methods
+
++ (void)addOverlayView:(OverlayView *)overlayView onView:(UIView *)view
+{
+
+   [view addSubview:overlayView];
+
+// Find the LeavesView and save it for forwarding touch events
+
+   NSEnumerator * enumer = [view.subviews objectEnumerator];
+   UIView * subview;
+   while ((subview = [enumer nextObject])) {
+      if ([subview isKindOfClass:[LeavesView class]]) {
+         overlayView.leavesView = (LeavesView *)subview;
+         break;
+      }
+   }
+
+}
+
+
+#pragma mark -
+#pragma mark Memory management
+
+/**
+ * <p>This is the designated initializer for both this class and UIView.
+ * </p>
+**/
+
+- (id)initWithFrame:(CGRect)rect
+{
+   if (self = [super initWithFrame:rect]) {
+      self.userInteractionEnabled = YES;
+      self.multipleTouchEnabled = YES;
+   }
+   return self;
+}
+
+
+#pragma mark -
+#pragma mark Forward touches outside active overlay area to LeavesView
+
+- (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event
+{
+   if (touchesBeganInLeavesView = touches.count == 1 && ! CGRectContainsPoint(CGRectInset(self.frame, leavesView.targetWidth, 0.0f), [event.allTouches.anyObject locationInView:self]))
+      [leavesView touchesBegan:touches withEvent:event];
+   else
+      [self.nextResponder touchesBegan:touches withEvent:event];
+}
+
+- (void)touchesMoved:(NSSet *)touches withEvent:(UIEvent *)event
+{
+   if (touchesBeganInLeavesView)
+      [leavesView touchesMoved:touches withEvent:event];
+   else
+      [self.nextResponder touchesMoved:touches withEvent:event];
+}
+
+- (void)touchesCancelled:(NSSet *)touches withEvent:(UIEvent *)event
+{
+   if (touchesBeganInLeavesView)
+      [super touchesCancelled:touches withEvent:event];
+   else
+      [self.nextResponder touchesCancelled:touches withEvent:event];
+}
+
+- (void)touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event
+{
+   if (touchesBeganInLeavesView)
+      [leavesView touchesEnded:touches withEvent:event];
+   else
+      [self.nextResponder touchesEnded:touches withEvent:event];
+}
+
+@end

--- a/Resources/OverlayExampleViewController.xib
+++ b/Resources/OverlayExampleViewController.xib
@@ -1,0 +1,364 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<archive type="com.apple.InterfaceBuilder3.CocoaTouch.iPad.XIB" version="7.10">
+	<data>
+		<int key="IBDocument.SystemTarget">800</int>
+		<string key="IBDocument.SystemVersion">10F569</string>
+		<string key="IBDocument.InterfaceBuilderVersion">788</string>
+		<string key="IBDocument.AppKitVersion">1038.29</string>
+		<string key="IBDocument.HIToolboxVersion">461.00</string>
+		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
+			<string key="NS.key.0">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+			<string key="NS.object.0">117</string>
+		</object>
+		<object class="NSMutableArray" key="IBDocument.EditedObjectIDs">
+			<bool key="EncodedWithXMLCoder">YES</bool>
+			<integer value="1"/>
+		</object>
+		<object class="NSArray" key="IBDocument.PluginDependencies">
+			<bool key="EncodedWithXMLCoder">YES</bool>
+			<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+		</object>
+		<object class="NSMutableDictionary" key="IBDocument.Metadata">
+			<bool key="EncodedWithXMLCoder">YES</bool>
+			<object class="NSArray" key="dict.sortedKeys" id="0">
+				<bool key="EncodedWithXMLCoder">YES</bool>
+			</object>
+			<object class="NSMutableArray" key="dict.values">
+				<bool key="EncodedWithXMLCoder">YES</bool>
+			</object>
+		</object>
+		<object class="NSMutableArray" key="IBDocument.RootObjects" id="1000">
+			<bool key="EncodedWithXMLCoder">YES</bool>
+			<object class="IBProxyObject" id="372490531">
+				<string key="IBProxiedObjectIdentifier">IBFilesOwner</string>
+				<string key="targetRuntimeIdentifier">IBIPadFramework</string>
+			</object>
+			<object class="IBProxyObject" id="975951072">
+				<string key="IBProxiedObjectIdentifier">IBFirstResponder</string>
+				<string key="targetRuntimeIdentifier">IBIPadFramework</string>
+			</object>
+			<object class="IBUIView" id="319976853">
+				<nil key="NSNextResponder"/>
+				<int key="NSvFlags">292</int>
+				<string key="NSFrameSize">{768, 1004}</string>
+				<object class="NSColor" key="IBUIBackgroundColor">
+					<int key="NSColorSpace">3</int>
+					<bytes key="NSWhite">MQA</bytes>
+					<object class="NSColorSpace" key="NSCustomColorSpace">
+						<int key="NSID">2</int>
+					</object>
+				</object>
+				<string key="targetRuntimeIdentifier">IBIPadFramework</string>
+			</object>
+			<object class="IBUIView" id="191373211">
+				<reference key="NSNextResponder"/>
+				<int key="NSvFlags">274</int>
+				<object class="NSMutableArray" key="NSSubviews">
+					<bool key="EncodedWithXMLCoder">YES</bool>
+					<object class="IBUILabel" id="941744980">
+						<reference key="NSNextResponder" ref="191373211"/>
+						<int key="NSvFlags">292</int>
+						<string key="NSFrame">{{20, 50}, {45, 21}}</string>
+						<reference key="NSSuperview" ref="191373211"/>
+						<bool key="IBUIOpaque">NO</bool>
+						<bool key="IBUIClipsSubviews">YES</bool>
+						<int key="IBUIContentMode">7</int>
+						<bool key="IBUIUserInteractionEnabled">NO</bool>
+						<string key="targetRuntimeIdentifier">IBIPadFramework</string>
+						<string key="IBUIText">Title:</string>
+						<object class="NSColor" key="IBUITextColor" id="1006885389">
+							<int key="NSColorSpace">1</int>
+							<bytes key="NSRGB">MCAwIDAAA</bytes>
+						</object>
+						<nil key="IBUIHighlightedColor"/>
+						<int key="IBUIBaselineAdjustment">1</int>
+						<float key="IBUIMinimumFontSize">10</float>
+					</object>
+					<object class="IBUISwitch" id="674166692">
+						<reference key="NSNextResponder" ref="191373211"/>
+						<int key="NSvFlags">292</int>
+						<string key="NSFrame">{{65, 47}, {94, 27}}</string>
+						<reference key="NSSuperview" ref="191373211"/>
+						<bool key="IBUIOpaque">NO</bool>
+						<string key="targetRuntimeIdentifier">IBIPadFramework</string>
+						<int key="IBUIContentHorizontalAlignment">0</int>
+						<int key="IBUIContentVerticalAlignment">0</int>
+						<bool key="IBUIOn">YES</bool>
+					</object>
+					<object class="IBUILabel" id="679366942">
+						<reference key="NSNextResponder" ref="191373211"/>
+						<int key="NSvFlags">292</int>
+						<string key="NSFrame">{{167, 47}, {581, 27}}</string>
+						<reference key="NSSuperview" ref="191373211"/>
+						<bool key="IBUIOpaque">NO</bool>
+						<bool key="IBUIClipsSubviews">YES</bool>
+						<int key="IBUIContentMode">7</int>
+						<bool key="IBUIUserInteractionEnabled">NO</bool>
+						<string key="targetRuntimeIdentifier">IBIPadFramework</string>
+						<string key="IBUIText">&lt;--- UISwitch and this UILabel are in OverlayExampleView.xib</string>
+						<object class="NSFont" key="IBUIFont">
+							<string key="NSName">Verdana</string>
+							<double key="NSSize">17</double>
+							<int key="NSfFlags">16</int>
+						</object>
+						<reference key="IBUITextColor" ref="1006885389"/>
+						<nil key="IBUIHighlightedColor"/>
+						<int key="IBUIBaselineAdjustment">1</int>
+						<float key="IBUIMinimumFontSize">10</float>
+					</object>
+				</object>
+				<string key="NSFrameSize">{768, 1004}</string>
+				<reference key="NSSuperview"/>
+				<object class="NSColor" key="IBUIBackgroundColor">
+					<int key="NSColorSpace">3</int>
+					<bytes key="NSWhite">MCAwAA</bytes>
+				</object>
+				<object class="IBUISimulatedStatusBarMetrics" key="IBUISimulatedStatusBarMetrics">
+					<int key="IBUIStatusBarStyle">2</int>
+				</object>
+				<string key="targetRuntimeIdentifier">IBIPadFramework</string>
+			</object>
+		</object>
+		<object class="IBObjectContainer" key="IBDocument.Objects">
+			<object class="NSMutableArray" key="connectionRecords">
+				<bool key="EncodedWithXMLCoder">YES</bool>
+				<object class="IBConnectionRecord">
+					<object class="IBCocoaTouchOutletConnection" key="connection">
+						<string key="label">overlayView</string>
+						<reference key="source" ref="372490531"/>
+						<reference key="destination" ref="191373211"/>
+					</object>
+					<int key="connectionID">8</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBCocoaTouchOutletConnection" key="connection">
+						<string key="label">view</string>
+						<reference key="source" ref="372490531"/>
+						<reference key="destination" ref="319976853"/>
+					</object>
+					<int key="connectionID">9</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBCocoaTouchOutletConnection" key="connection">
+						<string key="label">label</string>
+						<reference key="source" ref="372490531"/>
+						<reference key="destination" ref="679366942"/>
+					</object>
+					<int key="connectionID">11</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBCocoaTouchOutletConnection" key="connection">
+						<string key="label">onOffSwitch</string>
+						<reference key="source" ref="372490531"/>
+						<reference key="destination" ref="674166692"/>
+					</object>
+					<int key="connectionID">12</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBCocoaTouchEventConnection" key="connection">
+						<string key="label">switchValueChanged:</string>
+						<reference key="source" ref="674166692"/>
+						<reference key="destination" ref="372490531"/>
+						<int key="IBEventType">13</int>
+					</object>
+					<int key="connectionID">14</int>
+				</object>
+			</object>
+			<object class="IBMutableOrderedSet" key="objectRecords">
+				<object class="NSArray" key="orderedObjects">
+					<bool key="EncodedWithXMLCoder">YES</bool>
+					<object class="IBObjectRecord">
+						<int key="objectID">0</int>
+						<reference key="object" ref="0"/>
+						<reference key="children" ref="1000"/>
+						<nil key="parent"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">-1</int>
+						<reference key="object" ref="372490531"/>
+						<reference key="parent" ref="0"/>
+						<string key="objectName">File's Owner</string>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">-2</int>
+						<reference key="object" ref="975951072"/>
+						<reference key="parent" ref="0"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">3</int>
+						<reference key="object" ref="319976853"/>
+						<object class="NSMutableArray" key="children">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+						</object>
+						<reference key="parent" ref="0"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">1</int>
+						<reference key="object" ref="191373211"/>
+						<object class="NSMutableArray" key="children">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<reference ref="679366942"/>
+							<reference ref="674166692"/>
+							<reference ref="941744980"/>
+						</object>
+						<reference key="parent" ref="0"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">6</int>
+						<reference key="object" ref="674166692"/>
+						<reference key="parent" ref="191373211"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">10</int>
+						<reference key="object" ref="679366942"/>
+						<reference key="parent" ref="191373211"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">13</int>
+						<reference key="object" ref="941744980"/>
+						<reference key="parent" ref="191373211"/>
+					</object>
+				</object>
+			</object>
+			<object class="NSMutableDictionary" key="flattenedProperties">
+				<bool key="EncodedWithXMLCoder">YES</bool>
+				<object class="NSArray" key="dict.sortedKeys">
+					<bool key="EncodedWithXMLCoder">YES</bool>
+					<string>-1.CustomClassName</string>
+					<string>-2.CustomClassName</string>
+					<string>1.CustomClassName</string>
+					<string>1.IBEditorWindowLastContentRect</string>
+					<string>1.IBPluginDependency</string>
+					<string>10.IBPluginDependency</string>
+					<string>13.IBPluginDependency</string>
+					<string>3.IBEditorWindowLastContentRect</string>
+					<string>3.IBPluginDependency</string>
+					<string>6.IBPluginDependency</string>
+				</object>
+				<object class="NSMutableArray" key="dict.values">
+					<bool key="EncodedWithXMLCoder">YES</bool>
+					<string>OverlayExampleViewController</string>
+					<string>UIResponder</string>
+					<string>OverlayView</string>
+					<string>{{88, 59}, {783, 697}}</string>
+					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+					<string>{{178, 59}, {783, 697}}</string>
+					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+				</object>
+			</object>
+			<object class="NSMutableDictionary" key="unlocalizedProperties">
+				<bool key="EncodedWithXMLCoder">YES</bool>
+				<reference key="dict.sortedKeys" ref="0"/>
+				<object class="NSMutableArray" key="dict.values">
+					<bool key="EncodedWithXMLCoder">YES</bool>
+				</object>
+			</object>
+			<nil key="activeLocalization"/>
+			<object class="NSMutableDictionary" key="localizations">
+				<bool key="EncodedWithXMLCoder">YES</bool>
+				<reference key="dict.sortedKeys" ref="0"/>
+				<object class="NSMutableArray" key="dict.values">
+					<bool key="EncodedWithXMLCoder">YES</bool>
+				</object>
+			</object>
+			<nil key="sourceID"/>
+			<int key="maxID">14</int>
+		</object>
+		<object class="IBClassDescriber" key="IBDocument.Classes">
+			<object class="NSMutableArray" key="referencedPartialClassDescriptions">
+				<bool key="EncodedWithXMLCoder">YES</bool>
+				<object class="IBPartialClassDescription">
+					<string key="className">LeavesViewController</string>
+					<string key="superclassName">UIViewController</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">Leaves/LeavesViewController.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">OverlayExampleViewController</string>
+					<string key="superclassName">LeavesViewController</string>
+					<object class="NSMutableDictionary" key="actions">
+						<string key="NS.key.0">switchValueChanged:</string>
+						<string key="NS.object.0">id</string>
+					</object>
+					<object class="NSMutableDictionary" key="actionInfosByName">
+						<string key="NS.key.0">switchValueChanged:</string>
+						<object class="IBActionInfo" key="NS.object.0">
+							<string key="name">switchValueChanged:</string>
+							<string key="candidateClassName">id</string>
+						</object>
+					</object>
+					<object class="NSMutableDictionary" key="outlets">
+						<bool key="EncodedWithXMLCoder">YES</bool>
+						<object class="NSArray" key="dict.sortedKeys">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<string>label</string>
+							<string>onOffSwitch</string>
+							<string>overlayView</string>
+						</object>
+						<object class="NSMutableArray" key="dict.values">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<string>UILabel</string>
+							<string>UISwitch</string>
+							<string>OverlayView</string>
+						</object>
+					</object>
+					<object class="NSMutableDictionary" key="toOneOutletInfosByName">
+						<bool key="EncodedWithXMLCoder">YES</bool>
+						<object class="NSArray" key="dict.sortedKeys">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<string>label</string>
+							<string>onOffSwitch</string>
+							<string>overlayView</string>
+						</object>
+						<object class="NSMutableArray" key="dict.values">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<object class="IBToOneOutletInfo">
+								<string key="name">label</string>
+								<string key="candidateClassName">UILabel</string>
+							</object>
+							<object class="IBToOneOutletInfo">
+								<string key="name">onOffSwitch</string>
+								<string key="candidateClassName">UISwitch</string>
+							</object>
+							<object class="IBToOneOutletInfo">
+								<string key="name">overlayView</string>
+								<string key="candidateClassName">OverlayView</string>
+							</object>
+						</object>
+					</object>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">Classes/OverlayExampleViewController.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">OverlayView</string>
+					<string key="superclassName">UIView</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">Leaves/OverlayView.h</string>
+					</object>
+				</object>
+			</object>
+		</object>
+		<int key="IBDocument.localizationMode">0</int>
+		<string key="IBDocument.TargetRuntimeIdentifier">IBIPadFramework</string>
+		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDependencyDefaults">
+			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaTouchPlugin.iPhoneOS</string>
+			<integer value="800" key="NS.object.0"/>
+		</object>
+		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDevelopmentDependencies">
+			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaTouchPlugin.InterfaceBuilder3</string>
+			<integer value="3100" key="NS.object.0"/>
+		</object>
+		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>
+		<string key="IBDocument.LastKnownRelativeProjectPath">../Leaves.xcodeproj</string>
+		<int key="IBDocument.defaultPropertyAccessControl">3</int>
+		<string key="IBCocoaTouchPluginVersion">117</string>
+	</data>
+</archive>


### PR DESCRIPTION
1) In LeavesView.m, if you set a breakpoint in getImages, you'll notice that method is called twice when a LeavesViewController subclass is first loaded, when once would be sufficient.  In order to fix this, the "self.currentPageIndex = 0;" line from reloadData needed to be moved to layoutSubviews.

2) I also added an OverlayView class which works as you described in June (below).  It works from both initWithFrame:nibBundle and from a NIB.  When a series of touch events starts within the targetWidth of 
either side, it forwards all of the events in the series to the LeavesView, otherwise it will forward that series of events to the UIViewController.  There's an example that registers a delegate to update the overlay when the page is turned, as you suggested.
