### PR TITLE
Added retina support without breaking iOS 3.0

### DIFF
--- a/Leaves/LeavesCache.h
+++ b/Leaves/LeavesCache.h
@@ -14,8 +14,9 @@
 
 @property (nonatomic, assign) CGSize pageSize;
 @property (assign) id<LeavesViewDataSource> dataSource;
+@property (readonly) CGFloat scaleFactor;
 
-- (id)initWithPageSize:(CGSize)aPageSize;
+- (id)initWithPageSize:(CGSize)aPageSize andScaleFactor:(CGFloat)scaleFactor;
 - (CGImageRef)cachedImageForPageIndex:(NSUInteger)pageIndex;
 - (void)precacheImageForPageIndex:(NSUInteger)pageIndex;
 - (void)minimizeToPageIndex:(NSUInteger)pageIndex;

--- a/Leaves/LeavesCache.m
+++ b/Leaves/LeavesCache.m
@@ -17,11 +17,12 @@
 
 @implementation LeavesCache
 
-- (id)initWithPageSize:(CGSize)aPageSize
+- (id)initWithPageSize:(CGSize)aPageSize andScaleFactor:(CGFloat)fScaleFactor
 {
 	if (self = [super init]) {
 		_pageSize = aPageSize;
 		_pageCache = [[NSMutableDictionary alloc] init];
+        _scaleFactor = fScaleFactor;
 	}
 	return self;
 }
@@ -38,12 +39,15 @@
     
 	CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
 	CGContextRef context = CGBitmapContextCreate(NULL, 
-												 self.pageSize.width, 
-												 self.pageSize.height, 
+												 self.pageSize.width * self.scaleFactor,
+												 self.pageSize.height * self.scaleFactor,
 												 8,						/* bits per component*/
-												 self.pageSize.width * 4, 	/* bytes per row */
+												 self.pageSize.width * 4 * self.scaleFactor, 	/* bytes per row */
 												 colorSpace, 
 												 kCGImageAlphaPremultipliedLast | kCGBitmapByteOrder32Big);
+    
+    CGContextScaleCTM(context, self.scaleFactor, self.scaleFactor);
+    
 	CGColorSpaceRelease(colorSpace);
 	CGContextClipToRect(context, CGRectMake(0, 0, self.pageSize.width, self.pageSize.height));
 	

--- a/Leaves/LeavesView.m
+++ b/Leaves/LeavesView.m
@@ -22,6 +22,7 @@
 @property (nonatomic, assign) CGRect nextPageRect, prevPageRect;
 @property (nonatomic, assign) BOOL touchIsActive, interactionLocked;
 @property (readonly) LeavesCache *pageCache;
+@property (readonly) CGFloat scaleFactor;
 
 @end
 
@@ -78,6 +79,16 @@ CGFloat distance(CGPoint a, CGPoint b);
 							   nil];
 	_bottomPageShadow.startPoint = CGPointMake(0,0.5);
 	_bottomPageShadow.endPoint = CGPointMake(1,0.5);
+    
+    _scaleFactor = 1.0;
+    
+    // Check if iOS > 4
+    if ([[UIScreen mainScreen] respondsToSelector:@selector(scale)]){
+        _topPage.contentsScale = \
+        _topPageReverseImage.contentsScale = \
+        _bottomPage.contentsScale = \
+        _scaleFactor = [[UIScreen mainScreen] scale];
+    }
 	
 	[_topPage addSublayer:_topPageShadow];
 	[_topPage addSublayer:_topPageOverlay];
@@ -89,9 +100,9 @@ CGFloat distance(CGPoint a, CGPoint b);
 	[self.layer addSublayer:_topPage];
 	[self.layer addSublayer:_topPageReverse];
 	
-	_leafEdge = 1.0;
+    _leafEdge = 1.0;
     _backgroundRendering = NO;
-	_pageCache = [[LeavesCache alloc] initWithPageSize:self.bounds.size];
+    _pageCache = [[LeavesCache alloc] initWithPageSize:self.bounds.size andScaleFactor: self.scaleFactor];
 }
 
 - (id)initWithFrame:(CGRect)frame {


### PR DESCRIPTION
I saw a closed issue with a commit that fixed #3. It did so by breaking iOS 3.0 support. Even though I don't think anyone uses iOS3 anymore I still added retina support without breaking build for that platform. Just look at the code and see if you want it in the main repo.
